### PR TITLE
Remove --strip-components flag from tar command in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ env.EC2_HOST }} "
             set -e
             sudo mkdir -p ${{ env.TARGET_DIR }}
-            sudo tar xzf /tmp/site.tgz -C ${{ env.TARGET_DIR }} --strip-components=1
+            sudo tar xzf /tmp/site.tgz -C ${{ env.TARGET_DIR }}
           
             # Fix permissions for the current user
             sudo chown -R ubuntu:ubuntu ${{ env.TARGET_DIR }}


### PR DESCRIPTION
The flag was removed to preserve the original directory structure during extraction. This ensures the deployment process aligns better with the expected file layout in the target directory.